### PR TITLE
pinyin -> zhuyin in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,11 @@
 set(
     LIBPINYIN_HEADERS
-    pinyin.h
+    zhuyin.h
 )
 
 set(
     LIBPINYIN_SOURCES
-    pinyin.cpp
+    zhuyin.cpp
 )
 
 add_library(


### PR DESCRIPTION
Trivial name fix for cmake build.

After this fix, cmake still cannot build due to lack of `config.h`. cmake build needs to write a `config.h.in` and generates `config.h` according to it. That will not be a trivial fix, however.
