### PR TITLE
Change symbol versioning name to LIBZHUYIN

### DIFF
--- a/src/libzhuyin.ver
+++ b/src/libzhuyin.ver
@@ -1,4 +1,4 @@
-LIBPINYIN {
+LIBZHUYIN {
     global:
         zhuyin_init;
         zhuyin_save;


### PR DESCRIPTION
The symbol versioning name shall be LIBZHUYIN instead of LIBPINYIN.

This fix breaks ABI compatibility, so I am not sure if this is a good idea or not.
